### PR TITLE
fix: darkmode init

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -52,7 +52,7 @@
 		%sveltekit.head%
 
 		<!-- ダークテーマの事前適用を行う -->
-		<script src="/setup.js"></script>
+		<script src="setup.js"></script>
 	</head>
 	<body data-sveltekit-preload-data="hover">
 		<div style="display: contents">%sveltekit.body%</div>


### PR DESCRIPTION
ダークモードの適用がされなくなっていた問題を修正

原因：baseurlを設定したので setup.js の絶対パスが変わっていたため

Closes: #25 